### PR TITLE
Potential fix for code scanning alert no. 7: Potentially unsafe quoting

### DIFF
--- a/jq/jq.go
+++ b/jq/jq.go
@@ -8,12 +8,18 @@ import (
 	"github.com/shivuslr41/grpc-tester/exec"
 )
 
+// shellSingleQuote returns a shell-safe single-quoted representation of s.
+// It uses the POSIX pattern: 'foo'\''bar' to embed single quotes.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // Format a JSON string using the "jq -s" command-line tool.
 func Format(j string) (string, error) {
 	b, err := exec.NewCMD(
 		fmt.Sprintf(
-			"echo '%s' | jq -s '.'",
-			j,
+			"echo %s | jq -s '.'",
+			shellSingleQuote(j),
 		),
 	).CombinedOutput()
 	if err != nil {
@@ -26,9 +32,9 @@ func Format(j string) (string, error) {
 func Filter(j string, q string) (string, error) {
 	b, err := exec.NewCMD(
 		fmt.Sprintf(
-			"echo '%s' | jq -c %s",
-			j,
-			q,
+			"echo %s | jq -c %s",
+			shellSingleQuote(j),
+			shellSingleQuote(q),
 		),
 	).CombinedOutput()
 	if err != nil {
@@ -43,15 +49,15 @@ func Compare(r, e string, o bool) (bool, error) {
 	// If the "o" flag is set to true, the function sorts any arrays within the JSON strings before comparing them
 	if o {
 		command = fmt.Sprintf(
-			"jq --argjson a '%s' --argjson b '%s' -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b'",
-			r,
-			e,
+			"jq --argjson a %s --argjson b %s -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b'",
+			shellSingleQuote(r),
+			shellSingleQuote(e),
 		)
 	} else {
 		command = fmt.Sprintf(
-			"jq --argjson a '%s' --argjson b '%s' -n '($a == $b)'",
-			r,
-			e,
+			"jq --argjson a %s --argjson b %s -n '($a == $b)'",
+			shellSingleQuote(r),
+			shellSingleQuote(e),
 		)
 	}
 	b, err := exec.NewCMD(command).CombinedOutput()
@@ -65,10 +71,9 @@ func Compare(r, e string, o bool) (bool, error) {
 func Replace(o, q, d string) (string, error) {
 	b, err := exec.NewCMD(
 		fmt.Sprintf(
-			"echo '%s' | jq -rc '%s |= %s'",
-			o,
-			q,
-			d,
+			"echo %s | jq -rc %s",
+			shellSingleQuote(o),
+			shellSingleQuote(fmt.Sprintf("%s |= %s", q, d)),
 		),
 	).CombinedOutput()
 	if err != nil {
@@ -82,9 +87,9 @@ func Replace(o, q, d string) (string, error) {
 func Extract(o, q string) (string, error) {
 	b, err := exec.NewCMD(
 		fmt.Sprintf(
-			"echo '%s' | jq -rc '%s'",
-			o,
-			q,
+			"echo %s | jq -rc %s",
+			shellSingleQuote(o),
+			shellSingleQuote(q),
 		),
 	).CombinedOutput()
 	if err != nil {

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -34,7 +34,7 @@ func Filter(j string, q string) (string, error) {
 		fmt.Sprintf(
 			"echo %s | jq -c %s",
 			shellSingleQuote(j),
-			shellSingleQuote(q),
+			q,
 		),
 	).CombinedOutput()
 	if err != nil {
@@ -89,7 +89,7 @@ func Extract(o, q string) (string, error) {
 		fmt.Sprintf(
 			"echo %s | jq -rc %s",
 			shellSingleQuote(o),
-			shellSingleQuote(q),
+			q,
 		),
 	).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/shivuslr41/grpc-tester/security/code-scanning/7](https://github.com/shivuslr41/grpc-tester/security/code-scanning/7)

In general, the safest fix is to avoid manual shell quoting altogether and pass untrusted data to commands as separate arguments, letting the OS handle argument boundaries. For jq, this means calling it as `jq -rc 'filter' --argjson name value` (or reading JSON via stdin) without embedding the JSON content into the shell command string.

Given the constraints (only editing shown snippets, no changes to `exec.NewCMD`), the best fix is to escape single quotes and backslashes in the interpolated JSON before embedding it in single-quoted shell strings. For shell single-quoted strings, the standard escape pattern is to end the quote, insert an escaped quote, and reopen the quote: `'...'\''...'`. To implement this in Go, we can define a small helper function `shellSingleQuote` that returns a safely single-quoted version of an arbitrary string. Then we replace the vulnerable `fmt.Sprintf` strings so that they no longer use raw `%s` inside single quotes; instead we either:

- Pass already‑quoted strings (via `shellSingleQuote`) directly into the shell command (without extra quotes in the format string), or
- Use backslash escaping inside single quotes (but this is brittle and error‑prone compared to the `'\''` pattern).

The most robust and minimal‑behavior‑change approach here is:

1. Add a helper function in `jq/jq.go`:

```go
func shellSingleQuote(s string) string {
    // produce a shell-safe single-quoted literal
    return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
}
```

This treats any string as arbitrary bytes and safely wraps it into a shell single-quoted literal.

2. Update all command constructions that currently interpolate untrusted (or potentially untrusted) strings inside single quotes to instead use `shellSingleQuote`. Concretely:

- `Format`: `echo '%s'` should become `echo %s` with `shellSingleQuote(j)` passed as an argument, and the jq program `'.'` should be left as a literal (it’s static).
- `Filter`: same for `echo '%s'`. The jq filter `q` is also untrusted, so it should be single-quoted safely instead of interpolated raw; jq accepts its filter as a positional argument, so we can use `%s` with `shellSingleQuote(q)`.
- `Compare`: both `r` and `e` should be safely quoted when passed to `--argjson`. Instead of `--argjson a '%s'`, we use `--argjson a %s` and pass `shellSingleQuote(r)`, likewise for `b`.
- `Replace`: `o` (JSON input) should be shell-quoted safely when echoed. The filter `q` and expression `d` are also interpolated into a single-quoted jq program and may contain single quotes; those must also be shell-quoted when provided to jq. A safer layout is to use `jq -rc %s --argjson d %s` with `shellSingleQuote(q)` and `shellSingleQuote(d)` and keep the program constant (e.g., `'. | %s |= $d'`), but given the current pattern and limited visible context, we can at least ensure that `o` is shell‑escaped and that q/d are handled via `shellSingleQuote` when used as jq arguments rather than embedded directly in a single-quoted program.
- `Extract`: `o` and `q` should be shell-quoted safely when passed as arguments.

Since we must avoid changes outside shown snippets, and we don’t know whether `exec.NewCMD` expects a single string or command+args, we’ll keep using one string but make it shell‑safe by pre-quoting the interpolated values. We’ll:

- Add `shellSingleQuote` near the top of `jq/jq.go`.
- Change all `fmt.Sprintf` format strings to remove embedded single quotes around `%s` and instead insert pre-quoted values via `shellSingleQuote(...)`.
- For jq filters (`q`) and jq expressions (`d`), we will also pre-quote them and pass them where jq expects its filter argument instead of embedding them unescaped inside a single-quoted program string.

These changes stay within `jq/jq.go`, use only the existing `strings` import, and preserve functionality while preventing single quotes in the tainted data from breaking the shell quoting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
